### PR TITLE
Adds support for finding elements in the scope of an iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following is a list of available functions in Monocle:
 * Clear-MonocleElementValue
 * Close-MonocleBrowser
 * Edit-MonocleUrl
+* Enter-MonocleFrame
 * Get-Monocle2FACode
 * Get-MonocleElement
 * Get-MonocleElementAttribute

--- a/examples/iframes.ps1
+++ b/examples/iframes.ps1
@@ -1,0 +1,26 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]
+    $Url
+)
+
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+$path = "$($path)/src/Monocle.psm1"
+Import-Module $path -Force -ErrorAction Stop
+
+# Create a browser object
+$browser = New-MonocleBrowser -Type Chrome
+
+# Monocle runs commands in web flows, for easy disposal and test tracking
+Start-MonocleFlow -Name 'Elements in iFrames' -Browser $browser -ScriptBlock {
+
+    Set-MonocleUrl -Url $Url
+
+    Get-MonocleElement -Id 'fillform-frame-1' | Enter-MonocleFrame -ScriptBlock {
+        Get-MonocleElement -Id 'postcode_search' | Set-MonocleElementValue -Value 'NN1 1AA'
+        Get-MonocleElement -Id 'findAddressbtn' | Invoke-MonocleElementClick
+    }
+
+    Start-Sleep -Seconds 5
+
+} -CloseBrowser

--- a/src/Monocle.psd1
+++ b/src/Monocle.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Monocle.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.3.0'
+    ModuleVersion = '1.3.1'
 
     # ID used to uniquely identify this module
     GUID = '9dc3c8a1-664d-4253-a5d2-920250d3a15f'

--- a/src/Private/Tools.ps1
+++ b/src/Private/Tools.ps1
@@ -154,3 +154,13 @@ function Get-MonocleCustomDriverPath
 {
     return './custom_drivers'
 }
+
+function Add-MonocleOutputDepth
+{
+    $env:MONOCLE_OUTPUT_DEPTH = [string](([int]$env:MONOCLE_OUTPUT_DEPTH) + 1)
+}
+
+function Remove-MonocleOutputDepth
+{
+    $env:MONOCLE_OUTPUT_DEPTH = [string](([int]$env:MONOCLE_OUTPUT_DEPTH) - 1)
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -684,3 +684,40 @@ function Test-MonocleElementCSS
 
     return (Invoke-MonocleJavaScript -Script 'arguments[0].style[arguments[1]] == arguments[2]' -Arguments $Element, $Name, $Value)
 }
+
+function Enter-MonocleFrame
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [OpenQA.Selenium.IWebElement]
+        $Element,
+
+        [Parameter(Mandatory=$true)]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    # get the meta id of the element
+    $id = Get-MonocleElementId -Element $Element
+
+    try {
+        # enter the iframe
+        Write-MonocleHost -Message "Entering iFrame: $($id)"
+        $Browser.SwitchTo().Frame($Element) | Out-Null
+
+        # update the depth of output
+        Add-MonocleOutputDepth
+
+        # run the scriptblock
+        . $ScriptBlock
+    }
+    finally {
+        # reset the depth
+        Remove-MonocleOutputDepth
+
+        # exit the iframe back to the default frame
+        Write-MonocleHost -Message "Exiting iFrame: $($id)"
+        $Browser.SwitchTo().ParentFrame() | Out-Null
+    }
+}

--- a/src/Public/Flow.ps1
+++ b/src/Public/Flow.ps1
@@ -165,7 +165,7 @@ function Invoke-MonocleRetryScript
     }
 
     # update the depth of output
-    $env:MONOCLE_OUTPUT_DEPTH = [string](([int]$env:MONOCLE_OUTPUT_DEPTH) + 1)
+    Add-MonocleOutputDepth
 
     # attempt the logic
     $attempt = 1
@@ -187,5 +187,5 @@ function Invoke-MonocleRetryScript
     }
 
     # reset the depth
-    $env:MONOCLE_OUTPUT_DEPTH = [string](([int]$env:MONOCLE_OUTPUT_DEPTH) - 1)
+    Remove-MonocleOutputDepth
 }


### PR DESCRIPTION
Resolves #45

Adds a new `Enter-MonocleFrame` so we can select elements within an `iframe`.

Example:
```powershell
Get-MonocleElement -Id 'fillform-frame-1' | Enter-MonocleFrame -ScriptBlock {
    Get-MonocleElement -Id 'postcode_search' | Set-MonocleElementValue -Value 'NN1 1AA'
    Get-MonocleElement -Id 'findAddressbtn' | Invoke-MonocleElementClick
}
```